### PR TITLE
Textslackr

### DIFF
--- a/R/slackr.R
+++ b/R/slackr.R
@@ -324,6 +324,50 @@ ggslackr <- function(plot=last_plot(), channels=Sys.getenv("SLACK_CHANNEL"), sca
 
 }
 
+#' Sends basic text to a slack channel. Calls the chat.postMessage method on the Slack Web API.
+#' Information on this method can be found here: \url{https://api.slack.com/methods/chat.postMessage}
+#'
+#' @param text The character vector to be posted
+#' @param ... Optional arguments such as: as_user, parse, unfurl_links, etc.
+#' @param preformatted Should the text be sent as preformatted text. Defaults to TRUE
+#' @param channel The name of the channels to which the DataTable should be sent. 
+#'  Prepend channel names with a hashtag. Prepend private-groups with nothing.
+#'  Prepend direct messages with an @@
+#' @param username what user should the bot be named as (chr)
+#' @param icon_emoji what emoji to use (chr) \code{""} will mean use the default
+#' @param api_token your full slack.com API token
+#' @return The output of the curl
+#' @examples
+#' \dontrun{
+#' slackrSetup()
+#' textslackr('hello world', as_user=T)
+#' }
+#' @export
+textslackr <- function(text, ..., preformatted=T, channel=Sys.getenv("SLACK_CHANNEL"), username=Sys.getenv("SLACK_USERNAME"), 
+                        icon_emoji=Sys.getenv("SLACK_ICON_EMOJI"), api_token=Sys.getenv("SLACK_API_TOKEN")) {
+
+  if ( length(text) > 1 ) { stop("text must be a vector of length one") }
+  if ( !is.character(channel) | length(channel) > 1 ) { stop("channel must be a character vector of length one") }
+  if ( !is.logical(preformatted) | length(preformatted) > 1 ) { stop("preformatted must be a logical vector of length one") }
+  if ( !is.character(username) | length(username) > 1 ) { stop("username must be a character vector of length one") }
+  if ( !is.character(api_token) | length(api_token) > 1 ) { stop("api_token must be a character vector of length one") }
+
+  text <- as.character(text)
+
+  if ( preformatted ) {
+    if ( substr(text,1,3) != '```' ) { text <- paste0('```', text) }
+    if ( substr(text,nchar(text)-2,nchar(text)) != '```' ) { text <- paste0(text, '```') }
+  }
+
+  resp <- POST(url="https://slack.com/api/chat.postMessage",
+               body=list(token=api_token, channel=channel, username=username, icon_emoji=icon_emoji, text=text, link_names=1, ...))
+
+  warn_for_status(resp)
+
+  if (resp$status_code > 200) { print(str(expr)) }
+
+  return(resp)
+}
 
 #' Save R objects to an RData file on \code{slack.com}
 #'

--- a/tests/testthat/test-textslackr.R
+++ b/tests/testthat/test-textslackr.R
@@ -1,0 +1,8 @@
+context("textslackr")
+
+test_that("errors when given bad inputs", {
+	expect_error(textslackr(c(1,2),'api-test-private'), "text must be a vector of length one")
+	expect_error(textslackr('a',1),"channel must be a character vector of length one") 
+	expect_error(textslackr('a','api-test-private',preformatted='a'),"preformatted must be a logical vector of length one") 
+	expect_error(textslackr('a','api-test-private',icon_emoji=1),"icon_emoji must be a character vector of length one") 
+})


### PR DESCRIPTION
If a character object is passed to slackr::slackr, the name of the object is posted to slack rather than the contents of the object. If a character object is passed to slackr::textslackr, the contents of the object are posted. This pull request also includes some basic unit testing.
