### PR TITLE
Allow for filenames passed to figures through dev.slackr

### DIFF
--- a/R/slackr.R
+++ b/R/slackr.R
@@ -270,11 +270,12 @@ slackr <- function(...,
 #' }
 #' @export
 dev.slackr <- function(channels=Sys.getenv("SLACK_CHANNEL"), ...,
-                       api_token=Sys.getenv("SLACK_API_TOKEN")) {
+                       api_token=Sys.getenv("SLACK_API_TOKEN"),
+                       file='plot') {
 
   Sys.setlocale('LC_ALL','C')
 
-  ftmp <- tempfile("plot", fileext=".png")
+  ftmp <- tempfile(file, fileext=".png")
   dev.copy(png, file=ftmp, ...)
   dev.off()
 


### PR DESCRIPTION
Quick suggestion - all plots from dev.slackr are currently being posted as plotNNNNN - this quick fix should allow one to rename their plot.
