### PR TITLE
API expects a comma separated string, not a vector

### DIFF
--- a/R/slackr.R
+++ b/R/slackr.R
@@ -388,7 +388,7 @@ slackrUpload <- function(filename, title=basename(filename),
          add_headers(`Content-Type`="multipart/form-data"),
          body=list( file=upload_file(f_path), filename=f_name,
                     title=title, initial_comment=initial_comment,
-                    token=api_token, channels=modchan))
+                    token=api_token, channels=paste(modchan, collapse=",")))
 
   }
 


### PR DESCRIPTION
https://api.slack.com/methods/files.upload

"Comma separated list of channels to share the file into."
