### PR TITLE
docs: url_prefix->incoming_webhook_url

### DIFF
--- a/R/slackr_setup.r
+++ b/R/slackr_setup.r
@@ -38,7 +38,7 @@
 #'
 #' # the hard way
 #' slackr_setup(channel="#code", token="mytoken",
-#'             url_prefix="http://myslack.slack.com/services/hooks/incoming-webhook?")
+#'             incoming_webhook_url="http://myslack.slack.com/services/hooks/incoming-webhook?")
 #' }
 #' @export
 slackr_setup <- function(channel="#general", username="slackr",

--- a/README.Rmd
+++ b/README.Rmd
@@ -97,7 +97,7 @@ packageVersion("slackr")
 
 
 slackrSetup(channel="#code", 
-            url_prefix="http://myslack.slack.com/services/hooks/incoming-webhook?")
+            incoming_webhook_url="http://myslack.slack.com/services/hooks/incoming-webhook?")
 
 slackr(str(iris))
 

--- a/man/slackr_setup.Rd
+++ b/man/slackr_setup.Rd
@@ -63,7 +63,7 @@ slackr_setup(config_file="/path/to/my/slackrconfig)
 
 # the hard way
 slackr_setup(channel="#code", token="mytoken",
-            url_prefix="http://myslack.slack.com/services/hooks/incoming-webhook?")
+            incoming_webhook_url="http://myslack.slack.com/services/hooks/incoming-webhook?")
 }
 }
 \seealso{


### PR DESCRIPTION
- brings docs up to date with change to slackr_setup argmument name
