### PR TITLE
correction to documentation

### DIFF
--- a/R/dev_slackr.R
+++ b/R/dev_slackr.R
@@ -22,7 +22,7 @@
 #' # base
 #' library(maps)
 #' map("usa")
-#' dev_slackr("#results", filename='map')
+#' dev_slackr("#results", file='map')
 #'
 #' # base
 #' barplot(VADeaths)


### PR DESCRIPTION
`dev_slackr()` example used argument name 'filename' instead of 'file'. Updated.
