### PR TITLE
Added duplicate col 'real_name' to list of cols to exclude before joining

### DIFF
--- a/R/slackr_utils.R
+++ b/R/slackr_utils.R
@@ -54,7 +54,7 @@ slackr_users <- function(api_token=Sys.getenv("SLACK_API_TOKEN")) {
               body=list(token=api_token))
   stop_for_status(tmp)
   members <- jsonlite::fromJSON(content(tmp, as="text"))$members
-  cols <- setdiff(colnames(members), "profile")
+  cols <- setdiff(colnames(members), c("profile", "real_name"))
   cbind.data.frame(members[,cols], members$profile, stringsAsFactors=FALSE)
 
 }


### PR DESCRIPTION
Looks like the Slack API is now returning 'real_name' in the members$profile JSON:

```
> base::intersect(colnames(members), colnames(members$profile))
[1] "real_name"
```

```
==> devtools::test()

Loading slackr
Loading required package: testthat
Testing slackr
basic functionality: 
textslackr: 

DONE ===========================================================================
```
