### PR TITLE
Fix documentation of an argument

### DIFF
--- a/R/dev_slackr.R
+++ b/R/dev_slackr.R
@@ -10,7 +10,7 @@
 #' @return \code{httr} response object from \code{POST} call
 #' @seealso \code{\link{slackrSetup}}, \code{\link{save.slackr}}, \code{\link{slackrUpload}}
 #' @author Konrad Karczewski [ctb], Bob Rudis [aut]
-#' @note You can pass in \code{add_user=TRUE} as part of the \code{...} parameters and the Slack API
+#' @note You can pass in \code{as_user=TRUE} as part of the \code{...} parameters and the Slack API
 #'       will post the message as your logged-in user account (this will override anything set in
 #'       \code{username})
 #' @references \url{https://github.com/hrbrmstr/slackr/pull/12/files}

--- a/R/dev_slackr.R
+++ b/R/dev_slackr.R
@@ -12,7 +12,7 @@
 #' @author Konrad Karczewski [ctb], Bob Rudis [aut]
 #' @note You can pass in \code{as_user=TRUE} as part of the \code{...} parameters and the Slack API
 #'       will post the message as your logged-in user account (this will override anything set in
-#'       \code{username})
+#'       \code{username}).
 #' @references \url{https://github.com/hrbrmstr/slackr/pull/12/files}
 #' @rdname dev_slackr
 #' @examples

--- a/R/gg_slackr.R
+++ b/R/gg_slackr.R
@@ -17,7 +17,7 @@
 #' @param file prefix for filenames (defaults to \code{ggplot})
 #' @param ... other arguments passed to graphics device
 #' @note You need to setup a full API token (i.e. not a webhook & not OAuth) for this to work
-#'       Also, uou can pass in \code{add_user=TRUE} as part of the \code{...}
+#'       Also, uou can pass in \code{as_user=TRUE} as part of the \code{...}
 #'       parameters and the Slack API will post the message as your logged-in user
 #'       account (this will override anything set in \code{username})
 #' @return \code{httr} response object (invisibly)

--- a/R/slackr.R
+++ b/R/slackr.R
@@ -15,9 +15,11 @@
 #' @param api_token your full slack.com API token
 #' @note You need a \url{https://www.slack.com} account and will also need to
 #'       setup an API token \url{https://api.slack.com/}
-#'       Also, you can pass in \code{add_user=TRUE} as part of the \code{...}
+#'       Also, you can pass in \code{as_user=TRUE}, the default, as part of the \code{...}
 #'       parameters and the Slack API will post the message as your logged-in
-#'       user account (this will override anything set in \code{username})
+#'       user account (this will override anything set in \code{username}). 
+#'       Passing \code{as_user=FALSE}, results in the Slack API posting the
+#'       message as set in \code{username}.
 #' @seealso \code{\link{slackr_setup}}, \code{\link{slackr_bot}}, \code{\link{dev_slackr}},
 #'          \code{\link{save_slackr}}, \code{\link{slackr_upload}}
 #' @examples

--- a/R/slackr.R
+++ b/R/slackr.R
@@ -19,7 +19,7 @@
 #'       parameters and the Slack API will post the message as your logged-in
 #'       user account (this will override anything set in \code{username}). 
 #'       Passing \code{as_user=FALSE}, results in the Slack API posting the
-#'       message as set in \code{username}.
+#'       message as set in \code{username}
 #' @seealso \code{\link{slackr_setup}}, \code{\link{slackr_bot}}, \code{\link{dev_slackr}},
 #'          \code{\link{save_slackr}}, \code{\link{slackr_upload}}
 #' @examples

--- a/R/text_slackr.r
+++ b/R/text_slackr.r
@@ -12,7 +12,7 @@
 #' @param api_token your full slack.com API token
 #' @return \code{httr} response object (invislbly)
 #' @author Quinn Weber [aut], Bob Rudis [ctb]
-#' @note You can pass in \code{add_user=TRUE} as part of the \code{...} parameters and the Slack API
+#' @note You can pass in \code{as_user=TRUE} as part of the \code{...} parameters and the Slack API
 #'       will post the message as your logged-in user account (this will override anything set in
 #'       \code{username})
 #' @references \url{https://github.com/hrbrmstr/slackr/pull/11}


### PR DESCRIPTION
I changed argument `add_user` to `as_user` in the documentation, as per chat.postMessage.  In function slackr.R, the default is `as_user=TRUE` so the default behavior is to post as the logged-in user.  I indicated as such in the documentation.  It could be rewritten more succinctly but I wanted to change as little of your documentation as possible, particularly since it seems this is the only function with the default of `as_user=TRUE`
