### PR TITLE
Passing api_token correctly to slackrChTrans

### DIFF
--- a/R/dev_slackr.R
+++ b/R/dev_slackr.R
@@ -41,7 +41,7 @@ dev_slackr <- function(channels=Sys.getenv("SLACK_CHANNEL"), ...,
   dev.copy(png, file=ftmp, ...)
   dev.off()
 
-  modchan <- slackrChTrans(channels)
+  modchan <- slackrChTrans(channels, api_token)
 
   httr::POST(url="https://slack.com/api/files.upload",
              httr::add_headers(`Content-Type`="multipart/form-data"),

--- a/R/slackr_upload.R
+++ b/R/slackr_upload.R
@@ -28,7 +28,7 @@ slackr_upload <- function(filename, title=basename(filename),
     Sys.setlocale('LC_CTYPE','C')
     on.exit(Sys.setlocale("LC_CTYPE", loc))
 
-    modchan <- slackrChTrans(channels)
+    modchan <- slackrChTrans(channels, api_token)
 
     res <- httr::POST(url="https://slack.com/api/files.upload",
                       httr::add_headers(`Content-Type`="multipart/form-data"),


### PR DESCRIPTION
 slackrChTrans() is being called in slackr_upload() and dev_slackr(). But the api_token argument is not passed, forcing slackrChTrans() to use the default. This doesn't let users to pass the token as an argument to these functions if needed.