### PR TITLE
let extra params to be passed to the files.upload API endpoint

### DIFF
--- a/R/slackr_upload.R
+++ b/R/slackr_upload.R
@@ -9,6 +9,7 @@
 #' @param initial_comment comment for file on slack (optional - defaults to filename)
 #' @param channels Slack channels to save to (optional)
 #' @param api_token full API token
+#' @param ... other arguments passed to the API as per \url{https://api.slack.com/methods/files.upload}
 #' @return \code{httr} response object from \code{POST} call (invisibly)
 #' @author Quinn Weber [ctb], Bob Rudis [aut]
 #' @references \url{https://github.com/hrbrmstr/slackr/pull/15/files}
@@ -16,7 +17,7 @@
 #' @export
 slackr_upload <- function(filename, title=basename(filename),
                           initial_comment=basename(filename),
-                          channels="", api_token=Sys.getenv("SLACK_API_TOKEN")) {
+                          channels="", api_token=Sys.getenv("SLACK_API_TOKEN"), ...) {
 
   f_path <- path.expand(filename)
 
@@ -34,7 +35,7 @@ slackr_upload <- function(filename, title=basename(filename),
                       httr::add_headers(`Content-Type`="multipart/form-data"),
                       body=list( file=httr::upload_file(f_path), filename=f_name,
                                  title=title, initial_comment=initial_comment,
-                                 token=api_token, channels=paste(modchan, collapse=",")))
+                                 token=api_token, channels=paste(modchan, collapse=","), ...))
 
     return(invisible(res))
 

--- a/man/slackr_upload.Rd
+++ b/man/slackr_upload.Rd
@@ -7,11 +7,11 @@
 \usage{
 slackr_upload(filename, title = basename(filename),
   initial_comment = basename(filename), channels = "",
-  api_token = Sys.getenv("SLACK_API_TOKEN"))
+  api_token = Sys.getenv("SLACK_API_TOKEN"), ...)
 
 slackrUpload(filename, title = basename(filename),
   initial_comment = basename(filename), channels = "",
-  api_token = Sys.getenv("SLACK_API_TOKEN"))
+  api_token = Sys.getenv("SLACK_API_TOKEN"), ...)
 }
 \arguments{
 \item{filename}{path to file}
@@ -23,6 +23,8 @@ slackrUpload(filename, title = basename(filename),
 \item{channels}{Slack channels to save to (optional)}
 
 \item{api_token}{full API token}
+
+\item{...}{other arguments passed to the API as per \url{https://api.slack.com/methods/files.upload}}
 }
 \value{
 \code{httr} response object from \code{POST} call (invisibly)


### PR DESCRIPTION
Hi @hrbrmstr,

this is a very tiny update letting users pass extra args to the `files.upload` API endpoint, eg the recently introduced `parent_ts` so that we can upload files to threads.

Thanks,
Gergely