### PR TITLE
Fix file upload function

### DIFF
--- a/R/slackr.R
+++ b/R/slackr.R
@@ -17,7 +17,7 @@
 #'       setup an API token \url{https://api.slack.com/}
 #'       Also, you can pass in \code{as_user=TRUE}, the default, as part of the \code{...}
 #'       parameters and the Slack API will post the message as your logged-in
-#'       user account (this will override anything set in \code{username}). 
+#'       user account (this will override anything set in \code{username}).
 #'       Passing \code{as_user=FALSE}, results in the Slack API posting the
 #'       message as set in \code{username}
 #' @seealso \code{\link{slackr_setup}}, \code{\link{slackr_bot}}, \code{\link{dev_slackr}},
@@ -172,9 +172,9 @@ slackr_msg <- function(txt="",
   Sys.setlocale('LC_CTYPE','C')
   on.exit(Sys.setlocale("LC_CTYPE", loc))
 
-  resp <- POST(url="https://slack.com/api/chat.postMessage",
+  resp <- httr::POST(url="https://slack.com/api/chat.postMessage",
                body=list(token=api_token,
-                         channel=slackr_chtrans(channel),
+                         channel=channel,
                          username=username,
                          icon_emoji=icon_emoji,
                          text=output,
@@ -182,7 +182,7 @@ slackr_msg <- function(txt="",
                          link_names=1,
                          ...))
 
-  warn_for_status(resp)
+  httr::warn_for_status(resp)
 
   return(invisible())
 

--- a/R/slackr_upload.R
+++ b/R/slackr_upload.R
@@ -16,7 +16,7 @@
 #' @export
 slackr_upload <- function(filename, title=basename(filename),
                           initial_comment=basename(filename),
-                          channels="", api_token=Sys.getenv("SLACK_API_TOKEN")) {
+                          channel="general", api_token=Sys.getenv("SLACK_API_TOKEN")) {
 
   f_path <- path.expand(filename)
 
@@ -28,13 +28,11 @@ slackr_upload <- function(filename, title=basename(filename),
     Sys.setlocale('LC_CTYPE','C')
     on.exit(Sys.setlocale("LC_CTYPE", loc))
 
-    modchan <- slackrChTrans(channels, api_token)
-
     res <- httr::POST(url="https://slack.com/api/files.upload",
                       httr::add_headers(`Content-Type`="multipart/form-data"),
                       body=list( file=httr::upload_file(f_path), filename=f_name,
                                  title=title, initial_comment=initial_comment,
-                                 token=api_token, channels=paste(modchan, collapse=",")))
+                                 token=api_token, channels=channel))
 
     return(invisible(res))
 


### PR DESCRIPTION
I fixed this function to upload a file - it is less flexible (ie. only takes a single channel name), but it does now work with the API as it wasn't previously (the `slackrChTrans` function was the main culprit).

We are using this version in production so I thought it might be useful to push the fix through?