### PR TITLE
slackr 2.0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: slackr
 Type: Package
 Title: Send Messages, Images, R Objects and Files to 'Slack' Channels/Users
-Version: 2.0.0
+Version: 2.0.1
 Date: 2020-11-21
 Author: Bob Rudis [aut, cre], Jay Jacobs [ctb], David Severski [ctb],
     Quinn Weber [ctb], Konrad Karczewski [ctb], Shinya Uryu [ctb],
     Gregory Jefferis [ctb], Ed Niles [ctb], Rick Saporta [ctb],
-    Jonathan Sidi [aut, ctb], Matt Kaye [ctb]
+    Jonathan Sidi [aut, ctb], Matt Kaye [ctb], Xinye Li [ctb]
 Maintainer: Matt Kaye <mrkaye97@gmail.com>
 Description: 'Slack' <https://slack.com/> provides a service for teams to
     collaborate by sharing messages, images, links, files and more. Functions are provided

--- a/R/slackr_utils.R
+++ b/R/slackr_utils.R
@@ -15,8 +15,13 @@
 slackr_chtrans <- function(channels, bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUTH_TOKEN")) {
 
   chan <- slackr::slackr_channels(bot_user_oauth_token)
+  if (nrow(chan) == 0) {
+    stop("slackr is not seeing any channels in your workspace. Are you sure you have the right scopes enabled? See the readme for details.")
+  }
   users <- slackr::slackr_ims(bot_user_oauth_token)
-
+  if (nrow(chan) == 0) {
+    stop("slackr is not seeing any users in your workspace. Are you sure you have the right scopes enabled? See the ReadMe for details.")
+  }
   chan$name <- sprintf("#%s", chan$name)
   users$name <- sprintf("@%s", users$name)
 
@@ -93,5 +98,9 @@ slackr_ims <- function(bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUTH_TOK
   tmp <- httr::POST("https://slack.com/api/conversations.list?types=im", body=list(token=bot_user_oauth_token))
   ims <- jsonlite::fromJSON(httr::content(tmp, as="text"))$channels
   users <- slackr_users(bot_user_oauth_token)
+
+  if ((nrow(ims) == 0) | (nrow(users) == 0)) {
+    stop("slackr is not seeing any users in your workspace. Are you sure you have the right scopes enabled? See the readme for details.")
+  }
   dplyr::left_join(users, ims, by="id")
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -146,6 +146,10 @@ ggslackr(qplot(mpg, wt, data=mtcars))
 
 ```
 
+### Known Issues
+
+* Depending on your scopes, `slackr` could quietly fail (i.e. not throw an error, but also not post anything to your channel). If this happens, try explicitly adding the `slackr` app to your channel in your Slack workspace.
+
 ### Test Results
 
 ```{r test}

--- a/README.Rmd
+++ b/README.Rmd
@@ -95,6 +95,10 @@ You will need to have the following Bot Token Scopes enabled:
 
 Without these scopes, only certain functions will work.
 
+### Private Channels
+
+In some cases, it seems that the Slack API is not seeing private channels, and `slackr` fails as a result. If you are getting errors about not being able to find a channel, try making the channel public. You can test whether or not `slackr` will be able to see your channel by going [to this Slack API tester page](https://api.slack.com/methods/conversations.list/test), putting in your credentials, and seeing if your channel shows up.
+
 ### LaTeX for `tex_slackr`
 
 The new function `tex_slackr` in versions `2.0.0+` requires package [`texPreview`](https://github.com/yonicd/texPreview) which is lazy-loaded when the former is called.

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,11 +22,11 @@ knitr::opts_chunk$set(
 
 The `slackr` package contains functions that make it possible to interact with the Slack messaging platform. When you need to share information/data from R, rather than resort to copy/paste in e-mails or other services like Skype, you can use this package to send well-formatted output from multiple R objects and expressions to all teammates at the same time with little effort. You can also send images from the current graphics device, R objects (as R data files), and upload files.
 
-### BREAKING CHANGES
+## BREAKING CHANGES
 
 Version 2.0.0+ is updated to work with the new Slack API structure!
 
-### News
+## News
 
 - Version `2.0.0` fixes broken package because of changes to the Slack API
 - Version `1.4.2` fixes for changes to the Slack API causing duplicate column names and breaking functions
@@ -50,6 +50,8 @@ Many thanks to:
 - [Ed Niles](https://github.com/eniles)
 - [Rick Saporta](https://github.com/rsaporta)
 - [Jonathan Sidi](https://github.com/yonicd)
+- [Matt Kaye](https://github.com/mrkaye97)
+- [Xinye Li](https://github.com/xinye1)
 
 for their contributions to the package!
 
@@ -64,12 +66,11 @@ The following functions are implemented:
 - `slackr_upload` : upload any file to Slack
 - `slackr_users` : get a data frame of Slack
 - `slackr_channels` : get a data frame of Slack
-- `slackr_groups` : get a data frame of Slack groups
 - `text_slackr` : Send regular or preformatted messages to Slack
 - `slackr_msg` : Slightly different version of `text_slackr()`
 - `register_onexit`: Append an `on.exit` call to R functions (can be used with other package functions) and its output will be sent to a Slack channel.
 
-### SETUP
+## Setup
 
 The `slackr_setup()` function will try to read setup values from a `~/.slackr` (you can change the default) configuration file, which may be easier and more secure than passing them in manually (plus, will allow you to have multiple slackr configs for multiple Slack.com teams). The file is in Debian Control File (DCF) format since it really doesn't need to be JSON and R has a handy `read.dcf()` function since that's what `DESCRIPTION` files are coded in. Here's the basic format for the configuration file:
 
@@ -80,6 +81,30 @@ The `slackr_setup()` function will try to read setup values from a `~/.slackr` (
 
 You can also change the default emoji icon (from the one you setup at integration creation time) with `icon_emoji`.
 
+### Scopes
+
+You will need to have the following Bot Token Scopes enabled:
+* `channels:read`
+* `users:read`
+* `files:read`
+* `chat:write`
+* `chat:write.customize`
+* `chat:write.public`
+* `im:write`
+* `incoming-webhook`
+
+Without these scopes, only certain functions will work.
+
+### LaTeX for `tex_slackr`
+
+The new function `tex_slackr` in versions `2.0.0+` requires package [`texPreview`](https://github.com/yonicd/texPreview) which is lazy-loaded when the former is called.
+
+For setting up LaTeX see [`texPreview`'s System Requirements](https://github.com/yonicd/texPreview#functionality), and for specific OS setup check out its Github Actions like [this MacOS example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-mac.yml#L46).
+
+```{r opts, echo=FALSE, message=FALSE, warning=FALSE, error=FALSE}
+options(width=120)
+```
+
 ### Installation
 
 ```{r setup, eval=FALSE}
@@ -88,16 +113,6 @@ install.packages("slackr")
 
 # 2.0.0+
 devtools::install_github("mrkaye97/slackr")
-```
-
-#### LaTeX for `tex_slackr`
-
-The new function `tex_slackr` in versions `2.0.0+` requires package [`texPreview`](https://github.com/yonicd/texPreview) which is lazy-loaded when the former is called.
-
-For setting up LaTeX see [`texPreview`'s System Requirements](https://github.com/yonicd/texPreview#functionality), and for specific OS setup check out its Github Actions like [this MacOS example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-mac.yml#L46).
-
-```{r opts, echo=FALSE, message=FALSE, warning=FALSE, error=FALSE}
-options(width=120)
 ```
 
 ### Usage

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,6 +28,7 @@ Version 2.0.0+ is updated to work with the new Slack API structure!
 
 ## News
 
+- Version `2.0.1` adds documentation and suggested fixes to common bugs
 - Version `2.0.0` fixes broken package because of changes to the Slack API
 - Version `1.4.2` fixes for changes to the Slack API causing duplicate column names and breaking functions
 - Version `1.4.0.9000` new `slackr_msg()` + many fixes and BREAKING CHANGES (see above)

--- a/README.Rmd
+++ b/README.Rmd
@@ -156,6 +156,7 @@ ggslackr(qplot(mpg, wt, data=mtcars))
 ```{r test}
 library(slackr)
 library(testthat)
+slackr_setup()
 
 date()
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-ma
 
     # current verison
     packageVersion("slackr")
-    #> [1] '2.0.0'
+    #> [1] '2.0.1'
 
     slackrSetup(channel="#code", 
                 incoming_webhook_url="https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX")
@@ -170,6 +170,13 @@ example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-ma
 
     ggslackr(qplot(mpg, wt, data=mtcars))
 
+### Known Issues
+
+-   Depending on your scopes, `slackr` could quietly fail (i.e. not
+    throw an error, but also not post anything to your channel). If this
+    happens, try explicitly adding the `slackr` app to your channel in
+    your Slack workspace.
+
 ### Test Results
 
     library(slackr)
@@ -177,7 +184,7 @@ example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-ma
     #> Warning: package 'testthat' was built under R version 4.0.2
 
     date()
-    #> [1] "Sat Dec 12 23:35:20 2020"
+    #> [1] "Sat Dec 12 23:39:22 2020"
 
     devtools::test()
     #> Loading slackr
@@ -198,6 +205,8 @@ example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-ma
     #> 
     #> ══ Results ═════════════════════════════════════════════════════════════════════════════════════════════════════════════
     #> [ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]
+    #> 
+    #> Frustration is a natural part of programming :)
 
 ### Onexit Usage
 

--- a/README.md
+++ b/README.md
@@ -184,29 +184,21 @@ example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-ma
     library(slackr)
     library(testthat)
     #> Warning: package 'testthat' was built under R version 4.0.2
+    slackr_setup()
 
     date()
-    #> [1] "Sun Dec 13 09:14:03 2020"
+    #> [1] "Sun Dec 13 09:47:36 2020"
 
     devtools::test()
     #> Loading slackr
     #> Testing slackr
     #> ✓ |  OK F W S | Context
-    #> ⠏ |   0       | slackr                                                                                                  ⠏ |   0       | slackr                                                                                                  x |   0 1     | slackr
-    #> ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-    #> FAILURE (test_slackr.R:6:3): non-syntactic grouping variable is preserved (#1138)
-    #> `testresult` not equal to NULL.
-    #> Modes: character, NULL
-    #> Lengths: 1, 0
-    #> Attributes: < Modes: list, NULL >
-    #> Attributes: < Lengths: 2, 0 >
-    #> Attributes: < names for target but not for current >
-    #> Attributes: < current is not list-like >
-    #> target is try-error, current is NULL
-    #> ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+    #> ⠏ |   0       | slackr                                                                                                  ⠏ |   0       | slackr                                                                                                  ⠋ |   1       | slackr                                                                                                  ✓ |   1       | slackr [0.5 s]
     #> 
     #> ══ Results ═════════════════════════════════════════════════════════════════════════════════════════════════════════════
-    #> [ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]
+    #> Duration: 0.5 s
+    #> 
+    #> [ FAIL 0 | WARN 0 | SKIP 0 | PASS 1 ]
 
 ### Onexit Usage
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ You will need to have the following Bot Token Scopes enabled: \*
 
 Without these scopes, only certain functions will work.
 
+### Private Channels
+
+In some cases, it seems that the Slack API is not seeing private
+channels, and `slackr` fails as a result. If you are getting errors
+about not being able to find a channel, try making the channel public.
+You can test whether or not `slackr` will be able to see your channel by
+going [to this Slack API tester
+page](https://api.slack.com/methods/conversations.list/test), putting in
+your credentials, and seeing if your channel shows up.
+
 ### LaTeX for `tex_slackr`
 
 The new function `tex_slackr` in versions `2.0.0+` requires package
@@ -167,7 +177,7 @@ example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-ma
     #> Warning: package 'testthat' was built under R version 4.0.2
 
     date()
-    #> [1] "Sat Dec 12 23:25:57 2020"
+    #> [1] "Sat Dec 12 23:35:20 2020"
 
     devtools::test()
     #> Loading slackr

--- a/README.md
+++ b/README.md
@@ -21,71 +21,76 @@ teammates at the same time with little effort. You can also send images
 from the current graphics device, R objects (as R data files), and
 upload files.
 
-### BREAKING CHANGES
+BREAKING CHANGES
+----------------
 
-Version 2.0.0+ is updated to work with the new Slack API structure\!
+Version 2.0.0+ is updated to work with the new Slack API structure!
 
-### News
+News
+----
 
-  - Version `2.0.0` fixes broken package because of changes to the Slack
+-   Version `2.0.0` fixes broken package because of changes to the Slack
     API
-  - Version `1.4.2` fixes for changes to the Slack API causing duplicate
+-   Version `1.4.2` fixes for changes to the Slack API causing duplicate
     column names and breaking functions
-  - Version `1.4.0.9000` new `slackr_msg()` + many fixes and BREAKING
+-   Version `1.4.0.9000` new `slackr_msg()` + many fixes and BREAKING
     CHANGES (see above)
-  - Version `1.3.1.9000` Removed `data.table` dependency (replaced with
+-   Version `1.3.1.9000` Removed `data.table` dependency (replaced with
     `dplyr`); added access to `im.list`
-    (<https://api.slack.com/methods/im.list>) thx to PR from Quinn Weber
-  - Version `1.3.0.9000` Radically changed how `slackr` works. Functions
+    (<a href="https://api.slack.com/methods/im.list" class="uri">https://api.slack.com/methods/im.list</a>)
+    thx to PR from Quinn Weber
+-   Version `1.3.0.9000` Radically changed how `slackr` works. Functions
     have camelCase and under\_score versions
-  - Version `1.2.3` added more parameter error cheking, remobved the
+-   Version `1.2.3` added more parameter error cheking, remobved the
     need for ending `?` on webhook URL and added defaults for missing
     setup parameters.
-  - Version `1.2.2` fixed
+-   Version `1.2.2` fixed
     [issue](https://github.com/hrbrmstr/slackr/issues/4) (bug in `1.2.1`
     fix)
-  - Version `1.2.1` fixed
+-   Version `1.2.1` fixed
     [issue](https://github.com/hrbrmstr/slackr/issues/3) when there are
     no private groups defined
-  - Version `1.2` re-introduced `ggslackr()` (first [CRAN
+-   Version `1.2` re-introduced `ggslackr()` (first [CRAN
     version](http://cran.at.r-project.org/web/packages/slackr/index.html))
-  - Version `1.1.1` fixed a bug in the new full API `slackr()` function
-  - Version `1.1` added graphics & files capability
-  - Version `1.0` released
+-   Version `1.1.1` fixed a bug in the new full API `slackr()` function
+-   Version `1.1` added graphics & files capability
+-   Version `1.0` released
 
 Many thanks to:
 
-  - [Jay Jacobs](https://github.com/jayjacobs)
-  - [David Severski](https://github.com/davidski)
-  - [Quinn Weber](https://github.com/qsweber)
-  - [Konrad Karczewski](https://github.com/konradjk)
-  - [Ed Niles](https://github.com/eniles)
-  - [Rick Saporta](https://github.com/rsaporta)
-  - [Jonathan Sidi](https://github.com/yonicd)
+-   [Jay Jacobs](https://github.com/jayjacobs)
+-   [David Severski](https://github.com/davidski)
+-   [Quinn Weber](https://github.com/qsweber)
+-   [Konrad Karczewski](https://github.com/konradjk)
+-   [Ed Niles](https://github.com/eniles)
+-   [Rick Saporta](https://github.com/rsaporta)
+-   [Jonathan Sidi](https://github.com/yonicd)
+-   [Matt Kaye](https://github.com/mrkaye97)
+-   [Xinye Li](https://github.com/xinye1)
 
-for their contributions to the package\!
+for their contributions to the package!
 
 The following functions are implemented:
 
-  - `slackr_setup` : initialize necessary environment variables
-  - `slackr` : send stuff to Slack
-  - `slackr_bot` : send stuff to Slack using an incoming webhook URL
-  - `dev_slackr` : send the graphics contents of the current device to a
+-   `slackr_setup` : initialize necessary environment variables
+-   `slackr` : send stuff to Slack
+-   `slackr_bot` : send stuff to Slack using an incoming webhook URL
+-   `dev_slackr` : send the graphics contents of the current device to a
     to Slack channel
-  - `ggslackr` : send a ggplot object to a Slack channel (no existing
+-   `ggslackr` : send a ggplot object to a Slack channel (no existing
     device plot required, useful for scripts)
-  - `save_slackr` : save R objects to an RData file on Slack
-  - `slackr_upload` : upload any file to Slack
-  - `slackr_users` : get a data frame of Slack
-  - `slackr_channels` : get a data frame of Slack
-  - `slackr_groups` : get a data frame of Slack groups
-  - `text_slackr` : Send regular or preformatted messages to Slack
-  - `slackr_msg` : Slightly different version of `text_slackr()`
-  - `register_onexit`: Append an `on.exit` call to R functions (can be
+-   `save_slackr` : save R objects to an RData file on Slack
+-   `slackr_upload` : upload any file to Slack
+-   `slackr_users` : get a data frame of Slack
+-   `slackr_channels` : get a data frame of Slack
+-   `text_slackr` : Send regular or preformatted messages to Slack
+-   `slackr_msg` : Slightly different version of `text_slackr()`
+-   `register_onexit`: Append an `on.exit` call to R functions (can be
     used with other package functions) and its output will be sent to a
     Slack channel.
 
-### SETUP
+Setup
+-----
 
 The `slackr_setup()` function will try to read setup values from a
 `~/.slackr` (you can change the default) configuration file, which may
@@ -104,17 +109,16 @@ configuration file:
 You can also change the default emoji icon (from the one you setup at
 integration creation time) with `icon_emoji`.
 
-### Installation
+### Scopes
 
-``` r
-# original / no longer maintained
-install.packages("slackr")
+You will need to have the following Bot Token Scopes enabled: \*
+`channels:read` \* `users:read` \* `files:read` \* `chat:write` \*
+`chat:write.customize` \* `chat:write.public` \* `im:write` \*
+`incoming-webhook`
 
-# 2.0.0+
-devtools::install_github("mrkaye97/slackr")
-```
+Without these scopes, only certain functions will work.
 
-#### LaTeX for `tex_slackr`
+### LaTeX for `tex_slackr`
 
 The new function `tex_slackr` in versions `2.0.0+` requires package
 [`texPreview`](https://github.com/yonicd/texPreview) which is
@@ -125,97 +129,98 @@ Requirements](https://github.com/yonicd/texPreview#functionality), and
 for specific OS setup check out its Github Actions like [this MacOS
 example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-mac.yml#L46).
 
+### Installation
+
+    # original / no longer maintained
+    install.packages("slackr")
+
+    # 2.0.0+
+    devtools::install_github("mrkaye97/slackr")
+
 ### Usage
 
-``` r
-library(slackr)
+    library(slackr)
 
-# current verison
-packageVersion("slackr")
-#> [1] '2.0.0'
-```
+    # current verison
+    packageVersion("slackr")
+    #> [1] '2.0.0'
 
-``` r
-slackrSetup(channel="#code", 
-            incoming_webhook_url="https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX")
+    slackrSetup(channel="#code", 
+                incoming_webhook_url="https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX")
 
-slackr(str(iris))
+    slackr(str(iris))
 
-# send images
-library(ggplot2)
-qplot(mpg, wt, data=mtcars)
-dev.slackr("#results")
+    # send images
+    library(ggplot2)
+    qplot(mpg, wt, data=mtcars)
+    dev.slackr("#results")
 
-barplot(VADeaths)
-dev.slackr("@jayjacobs")
+    barplot(VADeaths)
+    dev.slackr("@jayjacobs")
 
-ggslackr(qplot(mpg, wt, data=mtcars))
-```
+    ggslackr(qplot(mpg, wt, data=mtcars))
 
 ### Test Results
 
-``` r
-library(slackr)
-library(testthat)
+    library(slackr)
+    library(testthat)
+    #> Warning: package 'testthat' was built under R version 4.0.2
 
-date()
-#> [1] "Wed Dec 02 20:00:31 2020"
+    date()
+    #> [1] "Sat Dec 12 23:25:57 2020"
 
-devtools::test()
-#> Loading slackr
-#> Testing slackr
-#> v |  OK F W S | Context
-#> / |   0       | slackr                                                                                                  / |   0       | slackr                                                                                                  x |   0 1     | slackr
-#> ------------------------------------------------------------------------------------------------------------------------
-#> FAILURE (test_slackr.R:6:3): non-syntactic grouping variable is preserved (#1138)
-#> `testresult` not equal to NULL.
-#> Modes: character, NULL
-#> Lengths: 1, 0
-#> Attributes: < Modes: list, NULL >
-#> Attributes: < Lengths: 2, 0 >
-#> Attributes: < names for target but not for current >
-#> Attributes: < current is not list-like >
-#> target is try-error, current is NULL
-#> ------------------------------------------------------------------------------------------------------------------------
-#> 
-#> == Results =============================================================================================================
-#> [ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]
-```
+    devtools::test()
+    #> Loading slackr
+    #> Testing slackr
+    #> ✓ |  OK F W S | Context
+    #> ⠏ |   0       | slackr                                                                                                  ⠏ |   0       | slackr                                                                                                  x |   0 1     | slackr
+    #> ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+    #> FAILURE (test_slackr.R:6:3): non-syntactic grouping variable is preserved (#1138)
+    #> `testresult` not equal to NULL.
+    #> Modes: character, NULL
+    #> Lengths: 1, 0
+    #> Attributes: < Modes: list, NULL >
+    #> Attributes: < Lengths: 2, 0 >
+    #> Attributes: < names for target but not for current >
+    #> Attributes: < current is not list-like >
+    #> target is try-error, current is NULL
+    #> ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+    #> 
+    #> ══ Results ═════════════════════════════════════════════════════════════════════════════════════════════════════════════
+    #> [ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]
 
 ### Onexit Usage
 
-``` r
- ctl <- c(4.17,5.58,5.18,6.11,4.50,4.61,5.17,4.53,5.33,5.14)
- trt <- c(4.81,4.17,4.41,3.59,5.87,3.83,6.03,4.89,4.32,4.69)
- group <- gl(2, 10, 20, labels = c("Ctl","Trt"))
- weight <- c(ctl, trt)
+     ctl <- c(4.17,5.58,5.18,6.11,4.50,4.61,5.17,4.53,5.33,5.14)
+     trt <- c(4.81,4.17,4.41,3.59,5.87,3.83,6.03,4.89,4.32,4.69)
+     group <- gl(2, 10, 20, labels = c("Ctl","Trt"))
+     weight <- c(ctl, trt)
 
- #pass a message to Slack channel 'general'
- register_onexit(lm,'bazinga!',channel="#general")
+     #pass a message to Slack channel 'general'
+     register_onexit(lm,'bazinga!',channel="#general")
 
- lm.D9 <- slack_lm(weight ~ group)
+     lm.D9 <- slack_lm(weight ~ group)
 
- #test that output keeps inheritance
- summary(lm.D9)
+     #test that output keeps inheritance
+     summary(lm.D9)
 
- #pass a message to Slack channel 'general' with a header message to begin output
- register_onexit(lm,'bazinga!',
- channel="#general",
- header_msg='This is a message to begin')
+     #pass a message to Slack channel 'general' with a header message to begin output
+     register_onexit(lm,'bazinga!',
+     channel="#general",
+     header_msg='This is a message to begin')
 
- lm.D9 <- slack_lm(weight ~ group)
+     lm.D9 <- slack_lm(weight ~ group)
 
- #onexit with an expression that calls lm.plot
- register_onexit(lm,{
-  par(mfrow = c(2, 2), oma = c(0, 0, 2, 0))
-  plot(z) #z is the internal output of stats::lm()
- },
- channel="#general",
- header_msg = 'This is a plot just for this output',
- use_device = TRUE)
+     #onexit with an expression that calls lm.plot
+     register_onexit(lm,{
+      par(mfrow = c(2, 2), oma = c(0, 0, 2, 0))
+      plot(z) #z is the internal output of stats::lm()
+     },
+     channel="#general",
+     header_msg = 'This is a plot just for this output',
+     use_device = TRUE)
 
- lm.D9 <- slack_lm(weight ~ group)
+     lm.D9 <- slack_lm(weight ~ group)
 
-#clean up slack channel from examples
-delete_slackr(count = 6,channel = '#general')
-```
+    #clean up slack channel from examples
+    delete_slackr(count = 6,channel = '#general')

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Version 2.0.0+ is updated to work with the new Slack API structure!
 News
 ----
 
+-   Version `2.0.1` adds documentation and suggested fixes to common
+    bugs
 -   Version `2.0.0` fixes broken package because of changes to the Slack
     API
 -   Version `1.4.2` fixes for changes to the Slack API causing duplicate
@@ -184,7 +186,7 @@ example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-ma
     #> Warning: package 'testthat' was built under R version 4.0.2
 
     date()
-    #> [1] "Sat Dec 12 23:39:22 2020"
+    #> [1] "Sun Dec 13 09:14:03 2020"
 
     devtools::test()
     #> Loading slackr
@@ -205,8 +207,6 @@ example](https://github.com/yonicd/texPreview/blob/master/.github/workflows/R-ma
     #> 
     #> ══ Results ═════════════════════════════════════════════════════════════════════════════════════════════════════════════
     #> [ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]
-    #> 
-    #> Frustration is a natural part of programming :)
 
 ### Onexit Usage
 

--- a/man/tex_slackr.Rd
+++ b/man/tex_slackr.Rd
@@ -36,7 +36,7 @@ eliminating the need write to pdf and convert to png to pass to slack.
 \details{
 Please make sure \code{texPreview} package is installed before running this function.
          For TeX setup refer to the
-         \href{https://github.com/hrbrmstr/slackr#installation}{installation notes}.
+         \href{https://github.com/hrbrmstr/slackr#latex-for-tex_slackr}{installation notes}.
 }
 \note{
 You need to setup a full API token (i.e. not a webhook & not OAuth) for this to work


### PR DESCRIPTION
This PR does a few things:
1. It updates the readme with much-needed documentation on common errors that have been referenced in issues multiple times in the past few weeks.
2. It sets up more informative errors for `slackr` to throw so the error messages that seem to be the most common are less cryptic.
3. It removes some deprecated function references from the readme

~@xinye1, it also looks like your test is failing. If you wanted to debug that and add the fix to this PR, that'd be awesome~