### PR TITLE
Fix tex_slackr document pointer to setup notes

### DIFF
--- a/R/tex_slackr.R
+++ b/R/tex_slackr.R
@@ -16,7 +16,7 @@
 #' @return \code{httr} response object (invisibly)
 #' @details Please make sure \code{texPreview} package is installed before running this function.
 #'          For TeX setup refer to the
-#'          \href{https://github.com/hrbrmstr/slackr#latex-for-tex_slackr}{installation notes}.
+#'          \href{https://github.com/mrkaye97/slackr#latex-for-tex_slackr}{Setup notes on \code{LaTeX}}.
 #' @examples
 #' \dontrun{
 #' slackr_setup()

--- a/man/tex_slackr.Rd
+++ b/man/tex_slackr.Rd
@@ -36,7 +36,7 @@ eliminating the need write to pdf and convert to png to pass to slack.
 \details{
 Please make sure \code{texPreview} package is installed before running this function.
          For TeX setup refer to the
-         \href{https://github.com/hrbrmstr/slackr#installation}{installation notes}.
+         \href{https://github.com/mrkaye97/slackr#latex-for-tex_slackr}{Setup notes on \code{LaTeX}}.
 }
 \note{
 You need to setup a full API token (i.e. not a webhook & not OAuth) for this to work


### PR DESCRIPTION
Now it's pointing to the `mrkaye97/slackr` repo