### PR TITLE
slakr_utils.R: support paging

### DIFF
--- a/R/slackr_utils.R
+++ b/R/slackr_utils.R
@@ -1,3 +1,47 @@
+#' Fetch Data from Slack API
+#'
+#' @param endpoint
+#' @param request_body_list
+#' @param result_jsonkey
+#' @param bot_user_oauth_token the Slack bot OAuth token (chr)
+#' @return list of \code{data.frame} of result
+#' @export
+slackr_fetchapi <- function(endpoint, request_keyvalue_list, result_jsonkey, paging_size=NULL, bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUTH_TOKEN")) {
+  loc <- Sys.getlocale('LC_CTYPE')
+  Sys.setlocale('LC_CTYPE','C')
+  on.exit(Sys.setlocale("LC_CTYPE", loc))
+
+
+  request_keyvalue_list <- append(request_keyvalue_list, list(token=bot_user_oauth_token))
+  if (!is.null(paging_size)) {
+    request_keyvalue_list <- append(request_keyvalue_list, list(limit=paging_size))
+  }
+
+  results <- list()
+  next_token <- NULL
+
+
+  repeat {
+    post_request_keyvalue_list <- append(request_keyvalue_list, list(cursor=next_token))
+
+    response <- httr::POST(paste0("https://slack.com/api/", endpoint), body=post_request_keyvalue_list)
+    httr::stop_for_status(response)
+    response_body <- jsonlite::fromJSON(httr::content(response, as="text"))
+
+    results <- append(results, list(response_body[[result_jsonkey]]))
+
+    next_token <- response_body$response_metadata$next_cursor
+    if (next_token == '') {
+      break
+    }
+
+    # message("slackr_fetchapi: found more information. fetching...")
+  }
+
+
+  results
+}
+
 #' Translate vector of channel names to channel ID's for API
 #'
 #' Given a vector of one or more channel names, it will retrieve list of
@@ -76,17 +120,23 @@ slackr_createcache <- function(bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_O
 #' @rdname slackr_users
 #' @export
 slackr_users <- function(bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUTH_TOKEN")) {
+  api_members_list <- slackr_fetchapi('users.list', list(), 'members', bot_user_oauth_token)
 
-  loc <- Sys.getlocale('LC_CTYPE')
-  Sys.setlocale('LC_CTYPE','C')
-  on.exit(Sys.setlocale("LC_CTYPE", loc))
+  users = NULL
 
-  tmp <- httr::POST("https://slack.com/api/users.list", body=list(token=bot_user_oauth_token))
-  httr::stop_for_status(tmp)
-  members <- jsonlite::fromJSON(httr::content(tmp, as="text"))$members
-  cols <- setdiff(colnames(members), c("profile", "real_name"))
-  cbind.data.frame(members[,cols], members$profile, stringsAsFactors=FALSE)
+  for (api_members in api_members_list) {
+    cols <- colnames(api_members)
+    cols <- setdiff(cols, c("profile", "real_name"))
+    members <- cbind.data.frame(api_members[,cols], api_members$profile, stringsAsFactors=FALSE)
 
+    if (is.null(users)) {
+      users <- members
+    } else {
+      users <- rbind(users, members)
+    }
+  }
+
+  users
 }
 
 
@@ -127,16 +177,25 @@ stop_for_status <- function(r) {
 #' @rdname slackr_channels
 #' @export
 slackr_channels <- function(bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUTH_TOKEN")) {
+  api_conversations_list <- slackr_fetchapi('conversations.list', list(types="public_channel,private_channel"), 'channels', 1000, bot_user_oauth_token)
 
-  loc <- Sys.getlocale('LC_CTYPE')
-  Sys.setlocale('LC_CTYPE','C')
-  on.exit(Sys.setlocale("LC_CTYPE", loc))
+  channels = NULL
 
-  tmp <- POST("https://slack.com/api/conversations.list?limit=500&types=public_channel,private_channel",
-              body=list(token=bot_user_oauth_token))
-  stop_for_status(tmp)
-  jsonlite::fromJSON(content(tmp, as="text"))$channels
+  for (api_conversations in api_conversations_list) {
+    cols <- colnames(api_conversations)
+    cols <- setdiff(cols, c("conversation_host_id", "frozen_reason", "last_read", "is_open", "priority"))
+    cols <- setdiff(cols, c("topic", "purpose"))
+    conversations <- cbind.data.frame(api_conversations[,cols], list(topic=api_conversations$topic), list(purpose=api_conversations$purpose), stringsAsFactors=FALSE)
 
+
+    if (is.null(channels)) {
+      channels <- conversations
+    } else {
+      channels <- rbind(channels, conversations)
+    }
+  }
+
+  channels
 }
 
 #' Get a data frame of Slack IM ids
@@ -148,13 +207,24 @@ slackr_channels <- function(bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUT
 #' @return \code{data.frame} of im ids and user names
 #' @export
 slackr_ims <- function(bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUTH_TOKEN")) {
+  api_conversations_list <- slackr_fetchapi('conversations.list', list(types="im"), 'channels', 1000, bot_user_oauth_token)
 
-  loc <- Sys.getlocale('LC_CTYPE')
-  Sys.setlocale('LC_CTYPE','C')
-  on.exit(Sys.setlocale("LC_CTYPE", loc))
+  ims = NULL
 
-  tmp <- httr::POST("https://slack.com/api/conversations.list?types=im", body=list(token=bot_user_oauth_token))
-  ims <- jsonlite::fromJSON(httr::content(tmp, as="text"))$channels
+  for (api_conversations in api_conversations_list) {
+    cols <- colnames(api_conversations)
+    cols <- setdiff(cols, c("conversation_host_id", "frozen_reason", "last_read", "is_open", "priority"))
+    cols <- setdiff(cols, c("topic", "purpose"))
+    conversations <- cbind.data.frame(api_conversations[,cols], stringsAsFactors=FALSE)
+
+
+    if (is.null(ims)) {
+      ims <- conversations
+    } else {
+      ims <- rbind(ims, conversations)
+    }
+  }
+
   users <- slackr_users(bot_user_oauth_token)
 
   if ((nrow(ims) == 0) | (nrow(users) == 0)) {
@@ -162,3 +232,4 @@ slackr_ims <- function(bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUTH_TOK
   }
   dplyr::left_join(users, ims, by="id")
 }
+


### PR DESCRIPTION
In my company's case, it cannot get all users and channels list at once. (my company's slack has users and channels each 1000+) So I cannot send some message or graph to some user or channel.

In slackr_utils.R, many functions have some pattern so I extract that to `slackr_fetchapi` function and add paging logic.