### PR TITLE
Minor Patches -- 2.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: slackr
 Type: Package
 Title: Send Messages, Images, R Objects and Files to 'Slack' Channels/Users
-Version: 2.1.0
+Version: 2.1.1
 Date: 2020-01-18
 Author: Bob Rudis [aut, cre], Jay Jacobs [ctb], David Severski [ctb],
     Quinn Weber [ctb], Konrad Karczewski [ctb], Shinya Uryu [ctb],

--- a/R/save_slackr.R
+++ b/R/save_slackr.R
@@ -17,7 +17,8 @@
 #' slackr_setup()
 #' save_slackr(mtcars, channels="#slackr", file="mtcars")
 #' }
-save_slackr <- function(..., channels="",
+save_slackr <- function(...,
+                        channels=Sys.getenv("SLACK_CHANNEL"),
                         file="slackr",
                         bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUTH_TOKEN"),
                         plot_text = '') {

--- a/R/slackr_bot.r
+++ b/R/slackr_bot.r
@@ -38,11 +38,18 @@
 #' }
 #' @export
 slackr_bot <- function(...,
+                       channel = '',
+                       username = '',
+                       icon_emoji = '',
                        incoming_webhook_url=Sys.getenv("SLACK_INCOMING_URL_PREFIX")) {
 
   if (incoming_webhook_url == "") {
     stop("No incoming webhook URL specified. Did you forget to call slackr_setup()?", call. = FALSE)
   }
+
+  if (channel != '') warning('The channel argument is deprecated as of slackr 2.1.1, as it no longer has any effect when used with a webhook')
+  if (username != '') warning('The username argument is deprecated as of slackr 2.1.1, as it no longer has any effect when used with a webhook')
+  if (icon_emoji != '') warning('The icon_emoji argument is deprecated as of slackr 2.1.1, as it no longer has any effect when used with a webhook')
 
   resp_ret <- ""
 

--- a/R/slackr_bot.r
+++ b/R/slackr_bot.r
@@ -8,13 +8,8 @@
 #' environment variable. You can override or just specify these values directly
 #' instead, but it's probably better to call [slackr_setup()] first.
 #'
-#' This function uses the incoming webhook API. The webhook will have a default
-#' channel, username, icon etc, but these can be overridden.
 #'
 #' @param ... expressions to be sent to Slack
-#' @param channel which channel to post the message to (chr)
-#' @param username what user should the bot be named as (chr)
-#' @param icon_emoji what emoji to use (chr) `""` will mean use the default
 #' @param incoming_webhook_url which `slack.com` API endpoint URL to use
 #'   (see section **Webhook URLs** for details)
 #' @importFrom utils URLencode
@@ -43,16 +38,11 @@
 #' }
 #' @export
 slackr_bot <- function(...,
-                       channel=Sys.getenv("SLACK_CHANNEL"),
-                       username=Sys.getenv("SLACK_USERNAME"),
-                       icon_emoji=Sys.getenv("SLACK_ICON_EMOJI"),
                        incoming_webhook_url=Sys.getenv("SLACK_INCOMING_URL_PREFIX")) {
 
   if (incoming_webhook_url == "") {
     stop("No incoming webhook URL specified. Did you forget to call slackr_setup()?", call. = FALSE)
   }
-
-  if (icon_emoji != "") { icon_emoji <- sprintf(', "icon_emoji": "%s"', icon_emoji)  }
 
   resp_ret <- ""
 
@@ -133,8 +123,8 @@ slackr_bot <- function(...,
         ),
       body = URLencode(
         sprintf(
-          "payload={\"channel\": \"%s\", \"username\": \"%s\", \"text\": \"```%s```\"%s}",
-          channel, username, output, icon_emoji)
+          "payload={\"text\": \"```%s```\"}",
+          output)
         )
       )
     stop_for_status(resp)

--- a/R/slackr_bot.r
+++ b/R/slackr_bot.r
@@ -12,6 +12,9 @@
 #' @param ... expressions to be sent to Slack
 #' @param incoming_webhook_url which `slack.com` API endpoint URL to use
 #'   (see section **Webhook URLs** for details)
+#' @param channel Deprecated. will have no effect
+#' @param username Deprecated. will have no effect
+#' @param icon_emoji Deprecated. will have no effect
 #' @importFrom utils URLencode
 #' @note You need a <https://www.slack.com> account and will also need to
 #'   setup an incoming webhook: <https://api.slack.com/>. Old style webhooks are

--- a/R/slackr_upload.R
+++ b/R/slackr_upload.R
@@ -17,7 +17,8 @@
 #' @export
 slackr_upload <- function(filename, title=basename(filename),
                           initial_comment=basename(filename),
-                          channels="", bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUTH_TOKEN")) {
+                          channels=Sys.getenv("SLACK_CHANNEL"),
+                          bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OAUTH_TOKEN")) {
 
   if (channels == '') stop("No channels specified. Did you forget select which channels to post to with the 'channels' argument?")
   f_path <- path.expand(filename)

--- a/R/slackr_upload.R
+++ b/R/slackr_upload.R
@@ -38,6 +38,8 @@ slackr_upload <- function(filename, title=basename(filename),
                                  title=title, initial_comment=initial_comment,
                                  token=bot_user_oauth_token, channels=paste(modchan, collapse=",")))
 
+    if (!content(res)$ok) stop(content(res)$error, ' -- Are you sure you used the right token and channel name?')
+
     return(invisible(res))
 
   } else {

--- a/man/save_slackr.Rd
+++ b/man/save_slackr.Rd
@@ -6,7 +6,7 @@
 \usage{
 save_slackr(
   ...,
-  channels = "",
+  channels = Sys.getenv("SLACK_CHANNEL"),
   file = "slackr",
   bot_user_oauth_token = Sys.getenv("SLACK_BOT_USER_OAUTH_TOKEN"),
   plot_text = ""

--- a/man/slackr_bot.Rd
+++ b/man/slackr_bot.Rd
@@ -4,10 +4,22 @@
 \alias{slackr_bot}
 \title{Send result of R expressions to a Slack channel via webhook API}
 \usage{
-slackr_bot(..., incoming_webhook_url = Sys.getenv("SLACK_INCOMING_URL_PREFIX"))
+slackr_bot(
+  ...,
+  channel = "",
+  username = "",
+  icon_emoji = "",
+  incoming_webhook_url = Sys.getenv("SLACK_INCOMING_URL_PREFIX")
+)
 }
 \arguments{
 \item{...}{expressions to be sent to Slack}
+
+\item{channel}{Deprecated. will have no effect}
+
+\item{username}{Deprecated. will have no effect}
+
+\item{icon_emoji}{Deprecated. will have no effect}
 
 \item{incoming_webhook_url}{which \code{slack.com} API endpoint URL to use
 (see section \strong{Webhook URLs} for details)}

--- a/man/slackr_bot.Rd
+++ b/man/slackr_bot.Rd
@@ -4,22 +4,10 @@
 \alias{slackr_bot}
 \title{Send result of R expressions to a Slack channel via webhook API}
 \usage{
-slackr_bot(
-  ...,
-  channel = Sys.getenv("SLACK_CHANNEL"),
-  username = Sys.getenv("SLACK_USERNAME"),
-  icon_emoji = Sys.getenv("SLACK_ICON_EMOJI"),
-  incoming_webhook_url = Sys.getenv("SLACK_INCOMING_URL_PREFIX")
-)
+slackr_bot(..., incoming_webhook_url = Sys.getenv("SLACK_INCOMING_URL_PREFIX"))
 }
 \arguments{
 \item{...}{expressions to be sent to Slack}
-
-\item{channel}{which channel to post the message to (chr)}
-
-\item{username}{what user should the bot be named as (chr)}
-
-\item{icon_emoji}{what emoji to use (chr) \code{""} will mean use the default}
 
 \item{incoming_webhook_url}{which \code{slack.com} API endpoint URL to use
 (see section \strong{Webhook URLs} for details)}
@@ -33,9 +21,6 @@ compute tasks or general information sharing.
 By default, everyting but \code{expr} will be looked for in a "\code{SLACK_}"
 environment variable. You can override or just specify these values directly
 instead, but it's probably better to call \code{\link[=slackr_setup]{slackr_setup()}} first.
-
-This function uses the incoming webhook API. The webhook will have a default
-channel, username, icon etc, but these can be overridden.
 }
 \note{
 You need a \url{https://www.slack.com} account and will also need to

--- a/man/slackr_upload.Rd
+++ b/man/slackr_upload.Rd
@@ -8,7 +8,7 @@ slackr_upload(
   filename,
   title = basename(filename),
   initial_comment = basename(filename),
-  channels = "",
+  channels = Sys.getenv("SLACK_CHANNEL"),
   bot_user_oauth_token = Sys.getenv("SLACK_BOT_USER_OAUTH_TOKEN")
 )
 }


### PR DESCRIPTION
This PR fixes a couple of things:

* It changes a few badly-set function default channels to be `Sys.getenv('SLACK_CHANNEL')` instead of `''`
* It adds a more informative error message on `slackr_upload()` when the request returns `not authed` as per #137 
* It deprecates some arguments in `slackr_bot()` that no longer work (username, channel, icon emoji) that used to work with the old API structure