### PR TITLE
Unbreaking the Vignettes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
-^.*Rmd$
 ^README.*$
 ^\.travis\.yml$
 ^slackr\.png$

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ tests/testthat/.config
 docs
 .config
 .slackr
-inst/doc

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: slackr
 Type: Package
 Title: Send Messages, Images, R Objects and Files to 'Slack' Channels/Users
-Version: 2.1.1
+Version: 2.1.2
 Date: 2020-01-18
 Author: Bob Rudis [aut, cre], Jay Jacobs [ctb], David Severski [ctb],
     Quinn Weber [ctb], Konrad Karczewski [ctb], Shinya Uryu [ctb],

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,6 +19,7 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/mrkaye97/slackr/workflows/R-CMD-check/badge.svg)](https://github.com/mrkaye97/slackr/actions)
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
 ![downloads](http://cranlogs.r-pkg.org/badges/grand-total/slackr)
+![downloads/month](https://cranlogs.r-pkg.org/badges/slackr)
 [![codecov](https://codecov.io/gh/mrkaye97/slackr/branch/master/graph/badge.svg?token=5HjUtFfIJR)](https://codecov.io/gh/mrkaye97/slackr)
 <!-- badges: end -->
 
@@ -68,6 +69,15 @@ permissions and is the simplest to set up, and will allow basic messaging to a
 specific channel.
 
 See the vignettes for setup instructions.
+
+
+## Vignettes
+
+The vignettes contain setup instructions and example usage:
+
+* Option 1 setup: `vignette('scoped-bot-setup', package = 'slackr')`
+* Option 2 setup: `vignette('webhook-setup', package = 'slackr')`
+* Usage: `vignette('using-slackr', package = 'slackr')`
 
 ### Config File Setup
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,6 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/mrkaye97/slackr/workflows/R-CMD-check/badge.svg)](https://github.com/mrkaye97/slackr/actions)
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
 ![downloads](http://cranlogs.r-pkg.org/badges/grand-total/slackr)
-![downloads/month](https://cranlogs.r-pkg.org/badges/slackr)
 [![codecov](https://codecov.io/gh/mrkaye97/slackr/branch/master/graph/badge.svg?token=5HjUtFfIJR)](https://codecov.io/gh/mrkaye97/slackr)
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ status](https://www.r-pkg.org/badges/version/slackr)](https://CRAN.R-project.org
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
 ![downloads](http://cranlogs.r-pkg.org/badges/grand-total/slackr)
-![downloads/month](https://cranlogs.r-pkg.org/badges/slackr)
 [![codecov](https://codecov.io/gh/mrkaye97/slackr/branch/master/graph/badge.svg?token=5HjUtFfIJR)](https://codecov.io/gh/mrkaye97/slackr)
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ status](https://www.r-pkg.org/badges/version/slackr)](https://CRAN.R-project.org
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
 ![downloads](http://cranlogs.r-pkg.org/badges/grand-total/slackr)
+![downloads/month](https://cranlogs.r-pkg.org/badges/slackr)
 [![codecov](https://codecov.io/gh/mrkaye97/slackr/branch/master/graph/badge.svg?token=5HjUtFfIJR)](https://codecov.io/gh/mrkaye97/slackr)
 <!-- badges: end -->
 
@@ -57,6 +58,14 @@ permissions and is the simplest to set up, and will allow basic
 messaging to a specific channel.
 
 See the vignettes for setup instructions.
+
+## Vignettes
+
+The vignettes contain setup instructions and example usage:
+
+  - Option 1 setup: `vignette('scoped-bot-setup', package = 'slackr')`
+  - Option 2 setup: `vignette('webhook-setup', package = 'slackr')`
+  - Usage: `vignette('using-slackr', package = 'slackr')`
 
 ### Config File Setup
 

--- a/vignettes/webhook-setup.Rmd
+++ b/vignettes/webhook-setup.Rmd
@@ -31,9 +31,9 @@ And that's it! You should be able to post a message with `slackr_bot('test messa
 
 ## Example Usage
 
-```{r}
+```r
 library(slackr)
-# slackr_setup()
+slackr_setup()
 
 slackr_bot('Test message', 
            channel = '#test',


### PR DESCRIPTION
This PR gets rid RMarkdown files in the build ignore so the vignettes work. I've also added a bit about how to access the vignettes in the readme.

I've bumped the version to 2.1.2 for this change. 