### PR TITLE
Fixing cachem bugs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: slackr
 Type: Package
 Title: Send Messages, Images, R Objects and Files to 'Slack' Channels/Users
-Version: 2.1.2
-Date: 2020-01-18
+Version: 2.1.3
+Date: 2020-02-26
 Author: Bob Rudis [aut, cre], Jay Jacobs [ctb], David Severski [ctb],
     Quinn Weber [ctb], Konrad Karczewski [ctb], Shinya Uryu [ctb],
     Gregory Jefferis [ctb], Ed Niles [ctb], Rick Saporta [ctb],
@@ -40,8 +40,8 @@ Imports:
     xtable (>= 1.8.4),
     tibble,
     magrittr,
-    memoise,
-    cachem
+    memoise (>= 2.0.0),
+    cachem (>= 1.0.4)
 RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3

--- a/R/slackr_utils.R
+++ b/R/slackr_utils.R
@@ -68,7 +68,8 @@ slackr_census_fun <- function(bot_user_oauth_token=Sys.getenv("SLACK_BOT_USER_OA
   distinct(chan_list)
 }
 
-if (Sys.getenv("SLACK_CACHE_DIR") == '') {
+cache_dir <- Sys.getenv("SLACK_CACHE_DIR")
+if (cache_dir == '') {
     slackr_census <- memoise::memoise(slackr_census_fun, cache = cachem::cache_mem())
 } else {
     slackr_census <- memoise::memoise(slackr_census_fun, cache = cachem::cache_disk(dir = cache_dir))


### PR DESCRIPTION
This PR fixes a couple of bugs related to memoization:
1. Bumps the required `memoise` version to `2.0.0+` (#140)
2. Bumps the required `cachem` version to `1.0.4+`
3. Fixes a bug with the `cache_dir` not being specified in `slackr_utils.R` (thanks @katrinabrock!)
